### PR TITLE
Updated footer to fix url for edit links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
   <footer>
     <hr>
-    <p><a href="{{ project-repository }}/blob/{{project-repository-branch}}{{ page.url }}">Edit</a> – <a href="{{ project-repository }}/issues/new">Discuss</a> – <a href="{{ work-url-about-page }}/">About</a> – <a href="{{ work-url-about-page }}/#licence">{{license.abbreviation}}</a></p>
+    <p><a href="{{ project-repository }}/blob/{{project-repository-branch}}/{{ page.path }}">Edit</a> – <a href="{{ project-repository }}/issues/new">Discuss</a> – <a href="{{ work-url-about-page }}/">About</a> – <a href="{{ work-url-about-page }}/#licence">{{license.abbreviation}}</a></p>
   </footer>
 
 </section>


### PR DESCRIPTION
This will fix the currently broken links at the bottom of the book pages when you want to "edit" the page